### PR TITLE
add a node

### DIFF
--- a/infra/lxd-cluster/main.tf
+++ b/infra/lxd-cluster/main.tf
@@ -11,3 +11,10 @@ module "node1" {
   cpu    = 1
   memory = "8GiB"
 }
+
+module "node2" {
+  source = "../modules/lxd-vms"
+  name   = "vm-2"
+  cpu    = 1
+  memory = "8GiB"
+}


### PR DESCRIPTION
This pull request adds a new module definition for `node2` in the `infra/lxd-cluster/main.tf` file, replicating the configuration of `node1` with 1 CPU and 8GiB of memory.

Infrastructure changes:

* Added a new `module "node2"` in `infra/lxd-cluster/main.tf`, sourcing from `../modules/lxd-vms` and configuring it with 1 CPU and 8GiB of memory.