### PR TITLE
destroy remaining node

### DIFF
--- a/infra/lxd-cluster/main.tf
+++ b/infra/lxd-cluster/main.tf
@@ -4,10 +4,3 @@ terraform {
     prefix = "./tf-deploy-lxd"
   }
 }
-
-module "node1" {
-  source = "../modules/lxd-vms"
-  name   = "vm-1"
-  cpu    = 1
-  memory = "8GiB"
-}


### PR DESCRIPTION
This pull request removes the `node1` module from the `infra/lxd-cluster/main.tf` file, simplifying the Terraform configuration by eliminating an unused VM definition.

Key change:

* [`infra/lxd-cluster/main.tf`](diffhunk://#diff-fcdb0644e019ee71c8ee0966ec684d0c54eb0b44908f543a5f3d77a1501d503bL7-L13): Removed the `node1` module, which included the configuration for a virtual machine (`vm-1`) with specific CPU and memory settings. 