### PR TITLE
add multi-vm creation

### DIFF
--- a/infra/lxd-cluster/main.tf
+++ b/infra/lxd-cluster/main.tf
@@ -4,3 +4,11 @@ terraform {
     prefix = "./tf-deploy-lxd"
   }
 }
+
+module "control-plane" {
+  source = "../modules/lxd-vms"
+  count = 1
+  name = "control-plane"
+  cpu = 4
+  memory = "6GiB"
+}

--- a/infra/lxd-cluster/main.tf
+++ b/infra/lxd-cluster/main.tf
@@ -7,8 +7,8 @@ terraform {
 
 module "control-plane" {
   source = "../modules/lxd-vms"
-  count = 1
-  name = "control-plane"
-  cpu = 4
+  count  = 1
+  name   = "control-plane"
+  cpu    = 4
   memory = "6GiB"
 }

--- a/infra/modules/lxd-vms/main.tf
+++ b/infra/modules/lxd-vms/main.tf
@@ -1,14 +1,21 @@
+resource "random_string" "suffix" {
+  count   = var.instance_count
+  length  = 8
+  special = false
+}
+
 resource "lxd_instance" "instance" {
-  name  = var.name
+  count = var.instance_count
+  name  = "${var.name}${count.index + 1}-${random_string.suffix[count.index].result}"
   image = "ubuntu:noble/amd64"
-  type = "virtual-machine"
+  type  = "virtual-machine"
   config = {
     "user.user-data" = file("${path.module}/cloud-init.yaml")
     "boot.autostart" = true
   }
 
   limits = {
-    cpu = var.cpu
+    cpu    = var.cpu
     memory = var.memory
   }
 }

--- a/infra/modules/lxd-vms/providers.tf
+++ b/infra/modules/lxd-vms/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     lxd = {
-      source = "terraform-lxd/lxd"
+      source  = "terraform-lxd/lxd"
       version = "2.5.0"
     }
   }

--- a/infra/modules/lxd-vms/variables.tf
+++ b/infra/modules/lxd-vms/variables.tf
@@ -3,11 +3,17 @@ variable "name" {
 }
 
 variable "cpu" {
-  type = number
+  type    = number
   default = 2
 }
 
 variable "memory" {
-  type = string
+  type    = string
   default = "4GiB"
+}
+
+variable "instance_count" {
+  description = "Number of instances to create"
+  type        = number
+  default     = 1
 }


### PR DESCRIPTION
Support the creation of multiple LXD virtual machine instances with dynamic naming and configuration. The most important changes include adding a new module for the control plane in the LXD cluster, updating the LXD VM module to handle multiple instances, and introducing a new variable for instance count.

### LXD VM Module Updates:
* Updated the `lxd_instance` resource in `infra/modules/lxd-vms/main.tf` to use a `count` parameter for creating multiple instances. Dynamic naming is implemented by appending an index and a random string suffix to the instance name.
* Added a `random_string` resource in `infra/modules/lxd-vms/main.tf` to generate unique suffixes for instance names, ensuring no naming conflicts when multiple instances are created.

### Configuration Improvements:
* Introduced a new `instance_count` variable in `infra/modules/lxd-vms/variables.tf` to specify the number of instances to create, with a default value of 1. This allows for flexible scaling of LXD VMs.